### PR TITLE
Fixed error due to encoding when open(mode=rb)

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -2035,11 +2035,13 @@ def stripUTF8_BOM(f):
 def readFile(filename, mode=u'r', continueOnError=False, displayError=True, encoding=None):
   try:
     if filename != u'-':
+      kwargs = {'encoding': GM.Globals[GM.SYS_ENCODING]} if u'b' not in mode else {}
+      
       if not encoding:
-        with open(os.path.expanduser(filename), mode, encoding=GM.Globals[GM.SYS_ENCODING]) as f:
+        with open(os.path.expanduser(filename), mode, **kwargs) as f:
           stripUTF8_BOM(f)
           return f.read()
-      with codecs.open(os.path.expanduser(filename), mode, encoding=encoding) as f:
+      with codecs.open(os.path.expanduser(filename), mode, **kwargs) as f:
 # codecs does not strip UTF-8 BOM (ef:bb:bf) so we must
         stripUTF8_BOM(f)
         return f.read()


### PR DESCRIPTION
gam update project produced the following error:
```python
Traceback (most recent call last):
  File "gam.py", line 39099, in ProcessGAMCommand
    MAIN_COMMANDS_WITH_OBJECTS[CL_command][CMD_FUNCTION][CL_objectName]()
  File "gam.py", line 6360, in doUpdateProject
    _, httpObj, login_hint, projects = _getLoginHintProjects(False)
  File "gam.py", line 6257, in _getLoginHintProjects
    cs_data = readFile(GC.Values[GC.CLIENT_SECRETS_JSON], mode=u'rb', continueOnError=True, displayError=True, encoding=None)
  File "gam.py", line 2039, in readFile
    with open(os.path.expanduser(filename), mode, encoding=GM.Globals[GM.SYS_ENCODING]) as f:
ValueError: binary mode doesn't take an encoding argument
```
Fixed with the PR. Not sure if there is a test suite anywhere to make sure it doesn't break something else (but it shouldn't).