### PR TITLE
use .get() to avoid KeyError for showbody

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -38795,7 +38795,7 @@ def printShowMessagesThreads(users, entityType):
     return headers+data
 
   def _getMessageBody(payload):
-    if 'attachmentId' not in payload['body'] and 'data' in payload['body']:
+    if 'attachmentId' not in payload.get('body', '') and 'data' in payload.get('body',''):
       return base64.urlsafe_b64decode(str(payload['body']['data'])).decode(UTF8)
     data = _getBodyData(payload, False)
     if data:


### PR DESCRIPTION
Was getting the following traceback for print threads showbody:
```python
Traceback (most recent call last):
  File "gam.py", line 40734, in ProcessGAMCommand
    USER_COMMANDS_WITH_OBJECTS[CL_command][CMD_FUNCTION][CL_objectName](entityList)
  File "gam.py", line 38047, in printShowThreads
    printShowMessagesThreads(users, Ent.THREAD)
  File "gam.py", line 38019, in printShowMessagesThreads
    _batchPrintShowMessagesThreads(service, user, jcount, messageIds, [_callbackPrintThread, _callbackPrintMessage][entityType == Ent.MESSAGE])
  File "gam.py", line 37918, in _batchPrintShowMessagesThreads
    dbatch.execute()
  File "/home/ryan/Projects/GAMADV-XTD3/src/googleapiclient/_helpers.py", line 130, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/home/ryan/Projects/GAMADV-XTD3/src/googleapiclient/http.py", line 1490, in execute
    self._callback(request_id, response, exception)
  File "gam.py", line 37895, in _callbackPrintThread
    _printThread(ri[RI_ENTITY], response)
  File "gam.py", line 37834, in _printThread
    _printMessage(user, message)
  File "gam.py", line 37805, in _printMessage
    row['Body'] = _getMessageBody(result['payload'])
  File "gam.py", line 37703, in _getMessageBody
    if 'attachmentId' not in payload['body'] and 'data' in payload['body']:
KeyError: 'body'
```
