### PR TITLE
Set max version for google-auth

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
 lxml
 cryptography
 google-api-python-client>=2.15
+google-auth<2.1.0


### PR DESCRIPTION
The `google-auth` library was recently updated, and the `CLOCK_SKEW` attribute has been refactored and is now `REFRESH_THRESHOLD`. Using `google-auth` 2.1.0 (latest) produces the following error:

```python
gam info domain
Traceback (most recent call last):
  File "/gam/src/gam/__init__.py", line 56782, in ProcessGAMCommand
    MAIN_COMMANDS_WITH_OBJECTS[CL_command][CMD_FUNCTION][CL_objectName]()
  File "/gam/src/gam/__init__.py", line 12680, in doInfoDomain
    doInfoInstance()
  File "/gam/src/gam/__init__.py", line 12646, in doInfoInstance
    doInfoCustomer(customerInfo, FJQC)
  File "/gam/src/gam/__init__.py", line 12558, in doInfoCustomer
    cd = buildGAPIObject(API.DIRECTORY)
  File "/gam/src/gam/__init__.py", line 4671, in buildGAPIObject
    credentials = getClientCredentials(api=api, refreshOnly=True)
  File "/gam/src/gam/__init__.py", line 3938, in getClientCredentials
    writeCreds, credentials = getOauth2TxtCredentials(api=api, noDASA=noDASA, refreshOnly=refreshOnly)
  File "/gam/src/gam/__init__.py", line 3840, in getOauth2TxtCredentials
    creds = google.oauth2.credentials.Credentials.from_authorized_user_info(jsonDict)
  File "/gam/src/gam/google/oauth2/credentials.py", line 352, in from_authorized_user_info
    expiry = _helpers.utcnow() - _helpers.CLOCK_SKEW
AttributeError: module 'google.auth._helpers' has no attribute 'CLOCK_SKEW'
```

See googleapis/google-auth-library-python#863 for the upstream change. This PR simply pins the version of `google-auth` to `<2.1.0` to avoid this issue.

A more permanent solution would be to update the `CLOCK_SKEW` variable to `REFRESH_THRESHOLD` in the vendored google code (`/gam/src/gam/google/oauth2/credentials.py`). I'm not quite sure why or how this google code is vendored into gam, so I just went for the simplest fix in this PR.