### PR TITLE
Full python3 path in install script

### DIFF
--- a/src/gam-install.sh
+++ b/src/gam-install.sh
@@ -224,6 +224,11 @@ fi
 $pycmd -V >/dev/null 2>&1
 rc=$?
 if (( $rc != 0 )); then
+  pycmd="/usr/bin/python3"
+fi
+$pycmd -V >/dev/null 2>&1
+rc=$?
+if (( $rc != 0 )); then
   pycmd="python2"
 fi
 $pycmd -V >/dev/null 2>&1


### PR DESCRIPTION
Fixes #285

Add default python3 install location ```/usr/bin/python3``` to the checks in the install script which try to work out whether python is installed.