### PR TITLE
Add publishing to winget job to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -605,3 +605,21 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           tar cJvvf bin.tar.xz bin/
+  
+  publish-winget:
+    runs-on: windows-latest
+    needs: build
+    name: Publish to WinGet
+    steps:
+      - name: Download GAM
+        uses: actions/download-artifact@v4
+        with:
+          name: gam-binaries
+          path: src
+      - name: Publish release to Winget Repo
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: taers232c.GAMADV-XTD3
+          version: ${GAMVERSION}
+          installers-regex: '\.msi$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -611,11 +611,10 @@ jobs:
     needs: build
     name: Publish to WinGet
     steps:
-      - name: Download GAM
+      - name: Download GAM artifact
         uses: actions/download-artifact@v4
         with:
           name: gam-binaries
-          path: src
       - name: Publish release to Winget Repo
         uses: vedantmgoyal2009/winget-releaser@v2
         with:


### PR DESCRIPTION
Heyo, this PR adds an additional job to your build yml which will auto publish new versions of your GAM to winget under the `taers232c.GAMADV-XTD3`.

Prior to accepting this PR (if you do) you'll need to create a github personal access token (PAT) with the `public_repo` scope, and add that token as `WINGET_TOKEN` into your build secrets, otherwise this job will fail since it can't create a PR at https://github.com/microsoft/winget-pkgs